### PR TITLE
fixes attributes, formatting, and null pointers

### DIFF
--- a/make-inc
+++ b/make-inc
@@ -22,6 +22,6 @@ CC = gcc-9
 CC = gcc
 
 # Linux LLVM C Compiler (clang) Options
-CCOPT = -DDEBUG=1 -std=gnu17 -g -Wall -O0
+CCOPT = -DDEBUG=1 -std=gnu17 -g -Wall -Wextra -Wformat -O0
 # Linux GNU C Compiler Options
-CCOPT = -DDEBUG=1 -std=gnu2x -g -Wall -Wextra -O0
+CCOPT = -DGCC=1 -DDEBUG=1 -std=gnu2x -g -Wall -Wextra -Wformat -O0

--- a/test/include/cbuf.h
+++ b/test/include/cbuf.h
@@ -27,14 +27,35 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // source: cbuf.h -- Quake command buffer
 
+#ifdef GCC
+void SZ_Init(sizebuf_t *buf, byte *data, int length)
+__attribute__ ((access (read_write, 1), access (read_only, 2), nonnull (1, 2)));
+
+void SZ_Clear(sizebuf_t* buf)
+__attribute__ ((access (read_write, 1), nonnull (1)));
+
+void *SZ_GetSpace(sizebuf_t *buf, int length)
+__attribute__ ((access (read_write, 1), nonnull (1)));
+
+int SZ_Write(sizebuf_t *buf, const void *src, int length)
+__attribute__ ((access (read_write, 1), access (read_only, 2), nonnull (1, 2)));
+
+int Cbuf_AddText(const char *text)
+__attribute__ ((access (read_only, 1), nonnull (1)));
+
+int Cbuf_Init(void);
+int Cbuf_AddEarlyCommands(qboolean clear);
+int Cbuf_Execute(void);
+#else
 void SZ_Init(sizebuf_t *buf, byte *data, int length);
 void SZ_Clear(sizebuf_t* buf);
 void *SZ_GetSpace(sizebuf_t *buf, int length);
-int SZ_Write(sizebuf_t *buf, const void *src, int length);
+int  SZ_Write(sizebuf_t *buf, const void *src, int length);
 
-int Cbuf_Init(void);
-int Cbuf_AddText(const char *text);
-int Cbuf_AddEarlyCommands(qboolean clear);
-int Cbuf_Execute(void);
+int  Cbuf_AddText(const char *text);
+int  Cbuf_Init(void);
+int  Cbuf_AddEarlyCommands(qboolean clear);
+int  Cbuf_Execute(void);
+#endif
 
 #endif

--- a/test/include/cmd.h
+++ b/test/include/cmd.h
@@ -26,12 +26,24 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 // source: cmd.h -- Quake script command processing module
 
-void Cmd_ExecuteString(const char *line);
-void Cmd_List_f(void);
-void Cmd_Wait_f(void);
-int  Cmd_AddCommand(const char *name, xcommand_t function);
-int  Cmd_Init(void);
-int  Cmd_Argc(void);
-char*Cmd_Argv(int const args);
+#ifdef GCC
+const char *Cmd_Argv(int const args)
+__attribute__ ((returns_nonnull));
+
+void Cmd_ExecuteString(const char *line)
+__attribute__ ((access (read_only, 1), nonnull (1)));
+
+int Cmd_AddCommand(const char *name, xcommand_t function)
+__attribute__ ((access (read_only, 1), nonnull (1, 2)));
+
+int Cmd_Init(void);
+int Cmd_Argc(void);
+#else
+const char *Cmd_Argv(int const args);
+void        Cmd_ExecuteString(const char *line);
+int         Cmd_AddCommand(const char *name, xcommand_t function);
+int         Cmd_Init(void);
+int         Cmd_Argc(void);
+#endif
 
 #endif

--- a/test/include/com.h
+++ b/test/include/com.h
@@ -26,6 +26,24 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 // source: com.h -- client / server communications
 
+#ifdef GCC
+void Com_Printf(const char *fmt, ...)
+__attribute__ ((access (read_only, 1), nonnull (1), format (printf, 1, 2)));
+
+void Com_Error(int const code, const char *fmt, ...)
+__attribute__ ((access (read_only, 2), nonnull (2), format (printf, 2, 3)));
+
+int  Com_InitArgv(int const argc, const char **argv)
+__attribute__ ((access (read_only, 2), nonnull (2)));
+
+int  Com_AddParam(const char *parm)
+__attribute__ ((access (read_only, 1), nonnull (1)));
+
+int  Com_Argc(void);
+void Com_ClearArgv(int const i);
+const char *Com_Argv(int const i) __attribute__ ((returns_nonnull));
+int  Com_ServerState(void);
+#else
 void Com_Printf(const char* fmt, ...);
 void Com_Error(int const code, const char* fmt, ...);
 int  Com_InitArgv(int const argc, const char **argv);
@@ -34,5 +52,6 @@ int  Com_Argc(void);
 void Com_ClearArgv(int const i);
 const char *Com_Argv(int const i);
 int  Com_ServerState(void);
+#endif
 
 #endif

--- a/test/include/cvar.h
+++ b/test/include/cvar.h
@@ -26,22 +26,26 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 // source: cvar.h -- dynamic command
 
-char *Cvar_VariableString(const char *var_name);
+#ifdef GCC
+const char *Cvar_VariableString(const char *var_name)
+__attribute__ ((access (read_only, 1), nonnull (1), returns_nonnull));
 
-int Cvar_Get(cvar_t *var,
-	     const char *var_name,
-	     const char *var_value,
-	     int const flags);
+int Cvar_Get(const char *var_name, const char *var_value, int const flags)
+__attribute__ ((access (read_only, 1), access (read_only, 2), nonnull (1, 2)));
 
-int Cvar_FullSet(cvar_t *var,
-		 const char *var_name,
-		 const char *var_value,
-		 int const flags);
+int Cvar_FullSet(const char *var_name, const char *var_value, int const flags)
+__attribute__ ((access (read_only, 1), access (read_only, 2), nonnull (1, 2)));
 
-int Cvar_Set(cvar_t *var,
-	     const char *var_name,
-	     const char *var_value);
+int Cvar_Set(const char *var_name, const char *var_value)
+__attribute__ ((access (read_only, 1), nonnull (1, 2)));
 
 int Cvar_Init(void);
+#else
+const char *Cvar_VariableString(const char *var_name);
+int Cvar_Get(const char *var_name, const char *var_value, int const flags);
+int Cvar_FullSet(const char *var_name, const char *var_value, int const flags);
+int Cvar_Set(const char *var_name, const char *var_value);
+int Cvar_Init(void);
+#endif
 
 #endif

--- a/test/include/util.h
+++ b/test/include/util.h
@@ -26,14 +26,25 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 // source: util.h
 
-int va(char *dst, int const size, const char *fmt, ...);
+#ifdef GCC
+int   va(char * __restrict__ dst, int const size, const char * __restrict__ fmt, ...)
+__attribute__ ((access (write_only, 1), access (read_only, 3), nonnull (1, 3),
+		format (printf, 3, 4)));
 
+int   Z_Init(void);
+void *Z_Free(void *ptr) __attribute__ ((access (read_write, 1)));
+int   Z_TagFree(short const tag);
+void *Z_TagMalloc(int const sizeObj, short const tag);
+void *Z_Malloc(int size);
+char *CopyString(const char *src) __attribute__ ((access (read_only, 1), nonnull (1)));
+#else
+int   va(char *dst, int const size, const char *fmt, ...);
 int   Z_Init(void);
 void *Z_Free(void *ptr);
 int   Z_TagFree(short const tag);
 void *Z_TagMalloc(int const sizeObj, short const tag);
 void *Z_Malloc(int size);
-
 char *CopyString(const char *src);
+#endif
 
 #endif

--- a/test/src/cbuf/cbuf.c
+++ b/test/src/cbuf/cbuf.c
@@ -31,6 +31,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "com.h"
 #include "util.h"
 #include "cmd.h"
+#include "cbuf.h"
 
 #define MAX_CMD_LEN 0x800
 #define MAX_SZBUF_LEN (4 * MAX_CMD_LEN)
@@ -39,9 +40,6 @@ static sizebuf_t cmd_text;
 static byte cmd_text_buf[MAX_SZBUF_LEN];
 extern qboolean cmd_wait;
 
-#if defined(__GCC__)
-__attribute__ ((access (write_only, 1), access (read_only, 2)))
-#endif
 void SZ_Init (sizebuf_t *buf, byte *data, int length)
 {
 	memset(buf, 0, sizeof(sizebuf_t));
@@ -53,18 +51,12 @@ void SZ_Init (sizebuf_t *buf, byte *data, int length)
 	buf->cursize = 0;
 }
 
-#if defined(__GCC__)
-__attribute__ ((access (read_write, 1)))
-#endif
 void SZ_Clear (sizebuf_t* buf)
 {
 	buf->overflowed = False;
 	buf->cursize = 0;
 }
 
-#if defined(__GCC__)
-__attribute__ ((access (read_write, 1)))
-#endif
 void *SZ_GetSpace (sizebuf_t *buf, int length)
 {
 	if ((buf->cursize + length) >= buf->maxsize) {
@@ -90,9 +82,6 @@ void *SZ_GetSpace (sizebuf_t *buf, int length)
 	return data;
 }
 
-#if defined(__GCC__)
-__attribute__ ((access (read_write, 1), access (read_only, 2)))
-#endif
 int SZ_Write (sizebuf_t *buf, const void *src, int length)
 {
 	void *dst = SZ_GetSpace(buf, length);
@@ -106,10 +95,6 @@ int SZ_Write (sizebuf_t *buf, const void *src, int length)
 	return ERR_ENONE;
 }
 
-#if defined(__GCC__)
-__attribute__ ((access (read_only, 1)))
-#endif
-
 int Cbuf_Init (void)
 {
 	memset(cmd_text_buf, 0, sizeof(cmd_text_buf));
@@ -117,9 +102,6 @@ int Cbuf_Init (void)
 	return ERR_ENONE;
 }
 
-#if defined(__GCC__)
-__attribute__ ((access (read_only, 1)))
-#endif
 int Cbuf_AddText (const char *text)
 {
 	int const length = strlen(text);

--- a/test/src/cmd/cmd.c
+++ b/test/src/cmd/cmd.c
@@ -31,6 +31,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "util.h"
 #include "com.h"
 #include "cvar.h"
+#include "cmd.h"
 
 typedef struct cmd_function_s {
 	struct cmd_function_s *next;
@@ -56,11 +57,11 @@ int Cmd_Argc (void)
 	return cmd_argc;
 }
 
-char *Cmd_Argv (int const args)
+const char *Cmd_Argv (int const args)
 {
 	int const argc = (args < 0)? -args : args;
 	if (argc >= cmd_argc) {
-		return NULL;
+		return "";
 	} else {
 		return cmd_argv[argc];
 	}
@@ -231,9 +232,6 @@ void Cmd_TokenizeString (const char **string_p)
 	}
 }
 
-#if defined(__GCC__)
-__attribute__ ((access (read_only, 1)))
-#endif
 void Cmd_ExecuteString (const char *line)
 {
 #if defined(DEBUG) && DEBUG
@@ -307,12 +305,9 @@ static int Cmd_Echo_f (void)
 }
 #endif
 
-#if defined(__GCC__)
-__attribute__ ((access (read_only, 1)))
-#endif
 int Cmd_AddCommand (const char *name, xcommand_t function)
 {
-	if (Cvar_VariableString(name)) {
+	if (Cvar_VariableString(name)[0]) {
 		Com_Printf("Cmd_AddCommand: %s already defined as a var\n", name);
 		return ERR_ENONE;
 	}

--- a/test/src/com/com.c
+++ b/test/src/com/com.c
@@ -21,12 +21,15 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 */
 
+// source: com.h -- client/server communications
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
 
 #include "q_shared.h"
+#include "com.h"
 
 #define STDC17 GNU_STD17
 
@@ -36,16 +39,19 @@ static int server_state = 0;
 static int com_argc = 0;
 static const char *com_argv[MAX_NUM_ARGVS];
 
-#if defined(__GCC__)
-__attribute__ ((access (read_write, 1), access (read_only, 2)))
+#ifdef GCC
+static void Com_Base (FILE *stream, const char *fmt, va_list args)
+__attribute__ ((access (write_only, 1), access (read_only, 2), nonnull (1, 2)));
+#else
+static void Com_Base (FILE *stream, const char *fmt, va_list args);
 #endif
-void Com_Base (FILE *stream, const char *fmt, va_list args)
+
+static void Com_Base (FILE *stream, const char *fmt, va_list args)
 {
 	vfprintf(stream, fmt, args);
 }
 
-#if (__GCC__ > 12) && (__STDC_VERSION__ > STDC17)
-__attribute__ ((access (read_only, 1)))
+#if (__GNUC__ > 12) && (__STDC_VERSION__ > STDC17)
 void Com_Printf (const char* fmt, ...)
 {
 	va_list args;
@@ -63,8 +69,7 @@ void Com_Printf (const char* fmt, ...)
 }
 #endif
 
-#if (__GCC__ > 12) && (__STDC_VERSION__ > STDC17)
-__attribute__ ((access (read_only, 2)))
+#if (__GNUC__ > 12) && (__STDC_VERSION__ > STDC17)
 void Com_Error (int const code, const char* fmt, ...)
 {
 	va_list args;
@@ -82,9 +87,6 @@ void Com_Error (int const code, const char* fmt, ...)
 }
 #endif
 
-#if defined(__GCC__)
-__attribute__ ((access (read_only, 2)))
-#endif
 int Com_InitArgv (int const argc, const char **argv)
 {
 	com_argc = argc;
@@ -109,9 +111,6 @@ int Com_InitArgv (int const argc, const char **argv)
 	return ERR_ENONE;
 }
 
-#if defined(__GCC__)
-__attribute__ ((access (read_only, 1)))
-#endif
 int Com_AddParam (const char *parm)
 {
 	if (com_argc == MAX_NUM_ARGVS) {

--- a/test/src/quake/quake.c
+++ b/test/src/quake/quake.c
@@ -39,9 +39,13 @@ int Quake_Free (void)
 	return Z_TagFree(0);
 }
 
-#if defined(__GCC__)
-__attribute__ ((access (read_only, 2)))
+#ifdef GCC
+int Quake_Init (int const argc, const char **argv)
+__attribute__ ((access (read_only, 2), nonnull (2)));
+#else
+int Quake_Init (int const argc, const char **argv);
 #endif
+
 int Quake_Init (int const argc, const char **argv)
 {
 	int rc = 0;
@@ -88,9 +92,6 @@ int Quake_Init (int const argc, const char **argv)
 	return rc;
 }
 
-#if defined(__GCC__)
-__attribute__ ((access (read_only, 2)))
-#endif
 int main (int const argc, const char **argv)
 {
 	int rc;

--- a/test/src/util/util.c
+++ b/test/src/util/util.c
@@ -31,6 +31,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "q_shared.h"
 #include "quake.h"
 #include "com.h"
+#include "util.h"
 
 #define STDC17 GNU_STD17
 #define Z_MAGIC 0x1d1d
@@ -47,11 +48,8 @@ static zhead_t z_chain;
 static int z_count = 0;
 static int z_bytes = 0;
 
-#if (__GCC__ > 12) && (__STDC_VERSION__ > STDC17)
-__attribute__ ((access (write_only, 1),
-		access (read_only, 3)),
-		nonnull (1, 3))
-int va (char *dst, int const size, const char *fmt, ...)
+#if (__GNUC__ > 12) && (__STDC_VERSION__ > STDC17)
+int va (char * __restrict__ dst, int const size, const char * __restrict__ fmt, ...)
 {
 	va_list args;
 	va_start(args);
@@ -61,7 +59,7 @@ int va (char *dst, int const size, const char *fmt, ...)
 	return rc;
 }
 #else
-int va (char *dst, int const size, const char *fmt, ...)
+int va (char * __restrict__ dst, int const size, const char * __restrict__ fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);
@@ -167,11 +165,6 @@ void *Z_Malloc (int size)
 	return Z_TagMalloc(size, tag);
 }
 
-#if defined(__GCC__)
-__attribute__ ((access (write_only, 1),
-		access (read_only, 2)),
-		nonull (2))
-#endif
 char *CopyString (const char *src)
 {
 	int const sz = strlen(src) + 1;


### PR DESCRIPTION
COMMENTS:
- adds GCC MACRO to differentiate clang from gcc so that clang won't complain about unknown attributes
- fixes formatting issues found by adding formatting attributes and warnings
- removes `cvar_t*` pointer from most Cvar functions that perform memory allocations ... the passed pointer will still be NULL so this is what it is meant by fixing the null pointer issue since one has to return the allocated pointer just like malloc does; we noted that the returned pointer is discarded in the original source so we do not bother to return it. -- No memory leaks since the zone linked-list has references to them.

valgrind reports no memory issues