### PR TITLE
protects read-only `cvar` fields

### DIFF
--- a/test/include/quake/type/cvar_t.h
+++ b/test/include/quake/type/cvar_t.h
@@ -28,9 +28,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 typedef struct cvar_s {
 	struct cvar_s *next;
-	char *name;
-	char *string;
-	char *latched_string;
+	const char *name;
+	const char *string;
+	const char *latched_string;
 	qboolean modified;
 	float value;
 	int flags;

--- a/test/include/util.h
+++ b/test/include/util.h
@@ -32,19 +32,22 @@ __attribute__ ((access (write_only, 1), access (read_only, 3), nonnull (1, 3),
 		format (printf, 3, 4)));
 
 int   Z_Init(void);
-void *Z_Free(void *ptr) __attribute__ ((access (read_write, 1)));
+void *Z_Free(void *ptr) __attribute__ ((access (read_only, 1)));
+const void *Z_FreeConst(const void *ptr) __attribute__ ((access (read_only, 1)));
 int   Z_TagFree(short const tag);
 void *Z_TagMalloc(int const sizeObj, short const tag);
 void *Z_Malloc(int size);
-char *CopyString(const char *src) __attribute__ ((access (read_only, 1), nonnull (1)));
+const char *CopyString(const char *src)
+__attribute__ ((access (read_only, 1), nonnull (1)));
 #else
 int   va(char *dst, int const size, const char *fmt, ...);
 int   Z_Init(void);
+const void *Z_FreeConst(const void *ptr);
 void *Z_Free(void *ptr);
 int   Z_TagFree(short const tag);
 void *Z_TagMalloc(int const sizeObj, short const tag);
 void *Z_Malloc(int size);
-char *CopyString(const char *src);
+const char *CopyString(const char *src);
 #endif
 
 #endif

--- a/test/src/cvar/cvar.c
+++ b/test/src/cvar/cvar.c
@@ -170,7 +170,7 @@ int Cvar_FullSet (const char *var_name, const char *var_value, int const flags)
 		userinfo_modified = True;
 	}
 
-	var->string = Z_Free(var->string);
+	var->string = Z_FreeConst(var->string);
 	var->string = CopyString(var_value);
 	if (!var->string) {
 		Com_Error(ERR_FATAL, "Cvar_FullSet: allocation error\n");
@@ -194,7 +194,7 @@ int Cvar_FullSet (const char *var_name, const char *var_value, int const flags)
 static int Cvar_Set2ForceFreeLatch (cvar_t *var)
 {
 	if (var->latched_string) {
-		var->latched_string = Z_Free(var->latched_string);
+		var->latched_string = Z_FreeConst(var->latched_string);
 	}
 
 	return ERR_ENONE;
@@ -216,7 +216,7 @@ static int Cvar_Set2Default (cvar_t *var, const char *var_name, const char *var_
 				return ERR_ENONE;
 			}
 
-			Z_Free(var->latched_string);
+			var->latched_string = Z_FreeConst(var->latched_string);
 
 		} else {
 
@@ -241,7 +241,7 @@ static int Cvar_Set2Default (cvar_t *var, const char *var_name, const char *var_
 
 		} else {
 
-			var->string = Z_Free(var->string);
+			var->string = Z_FreeConst(var->string);
 			var->string = CopyString(var_value);
 			if (!var->string) {
 				char errmsg[] = "Cvar_Set2: allocation error\n";
@@ -307,7 +307,7 @@ static int Cvar_Set2 (const char *var_name,
 		userinfo_modified = True;
 	}
 
-	var->string = Z_Free(var->string);
+	var->string = Z_FreeConst(var->string);
 	var->string = CopyString(var_value);
 	if (!var->string) {
 		Com_Error(ERR_FATAL, "Cvar_Set2: failed to allocaote var->string\n");


### PR DESCRIPTION
COMMENTS:
`name`, `string` and `latched_string` are write-protected fields in the original source (as expressed by the authors) that should not be modified outside `Cvar` methods; this commit experiments with making them `const` so that the compiler will complain about writing to them.