### PR TITLE
adds `Cmd_Exec_f()` for script execution

### DIFF
--- a/test/include/cbuf.h
+++ b/test/include/cbuf.h
@@ -40,6 +40,9 @@ __attribute__ ((access (read_write, 1), nonnull (1)));
 int SZ_Write(sizebuf_t *buf, const void *src, int length)
 __attribute__ ((access (read_write, 1), access (read_only, 2), nonnull (1, 2)));
 
+int Cbuf_InsertText(const char *text)
+__attribute__ ((access (read_only, 1), nonnull (1)));
+
 int Cbuf_AddText(const char *text)
 __attribute__ ((access (read_only, 1), nonnull (1)));
 
@@ -52,6 +55,7 @@ void SZ_Clear(sizebuf_t* buf);
 void *SZ_GetSpace(sizebuf_t *buf, int length);
 int  SZ_Write(sizebuf_t *buf, const void *src, int length);
 
+int  Cbuf_InsertText(const char *text);
 int  Cbuf_AddText(const char *text);
 int  Cbuf_Init(void);
 int  Cbuf_AddEarlyCommands(qboolean clear);

--- a/test/include/fs.h
+++ b/test/include/fs.h
@@ -30,9 +30,17 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 int FS_SetGameDir(const char *dir)
 __attribute__ ((access (read_only, 1), nonnull (1)));
 
+int FS_FreeFile(char **data)
+__attribute__ ((access (read_write, 1), nonnull (1)));
+
+int FS_LoadFile(const char *filename, char **data)
+__attribute__ ((access (read_only, 1), access (read_write, 2), nonnull (1, 2)));
+
 int FS_InitFileSystem(void);
 #else
 int FS_SetGameDir(const char *dir);
+int FS_FreeFile(char **data);
+int FS_LoadFile(const char *filename, char **data)
 int FS_Init(void);
 #endif
 

--- a/test/src/cbuf/cbuf.c
+++ b/test/src/cbuf/cbuf.c
@@ -108,6 +108,12 @@ int Cbuf_AddText (const char *text)
 	return SZ_Write(&cmd_text, text, length);
 }
 
+int Cbuf_InsertText (const char *text)
+{
+	Com_Printf("Cbuf_InsertText: NOT YET IMPLEMENTED\n");
+	return ERR_ENONE;
+}
+
 int Cbuf_AddEarlyCommands (qboolean clear)
 {
 	int rc;

--- a/test/src/cmd/make-inc
+++ b/test/src/cmd/make-inc
@@ -20,10 +20,12 @@ Q_SHARED_H = ../../include/q_shared.h
 QUAKE_H    = ../../include/quake.h
 UTIL_H     = ../../include/util.h
 COM_H      = ../../include/com.h
+FS_H       = ../../include/fs.h
 HEADERS = $(Q_SHARED_H)\
 	  $(QUAKE_H)\
 	  $(UTIL_H)\
-	  $(COM_H)
+	  $(COM_H)\
+	  $(FS_H)
 
 # sources
 CMD_C = cmd.c

--- a/test/src/fs/make-inc
+++ b/test/src/fs/make-inc
@@ -23,13 +23,15 @@ UTIL_H     = ../../include/util.h
 CBUF_H     = ../../include/cbuf.h
 CMD_H      = ../../include/cmd.h
 CVAR_H     = ../../include/cvar.h
+FS_H       = ../../include/fs.h
 HEADERS = $(Q_SHARED_H)\
 	  $(QUAKE_H)\
 	  $(COM_H)\
 	  $(UTIL_H)\
 	  $(CBUF_H)\
 	  $(CMD_H)\
-	  $(CVAR_H)
+	  $(CVAR_H)\
+	  $(FS_H)
 
 # sources
 FS_C = fs.c


### PR DESCRIPTION
COMMENTS:
not yet functional because we need to implement `Cbuf_InsertText()`

opted to append the NULL char to the file contents to save one memory allocation ... still need to check if doing this breaks things not yet added from the original source.

we have not tested executing a Quake script yet ... so maybe some fun debugging awaits us